### PR TITLE
Use the Python 2 binary

### DIFF
--- a/wall.py
+++ b/wall.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 # Wall
 


### PR DESCRIPTION
Use the Python 2 binary as shebang, because we have no Python 3 support at the moment.
