### PR TITLE
Fix and improve logging at startup

### DIFF
--- a/wall.py
+++ b/wall.py
@@ -13,5 +13,4 @@ from wall import WallApp
 if __name__ == '__main__':
     # TODO: use option instead
     config_path = sys.argv[1] if len(sys.argv) >= 2 else None
-    print('Wall #{}'.format(wall.release))
     WallApp(config_path=config_path).run()

--- a/wall/__init__.py
+++ b/wall/__init__.py
@@ -228,9 +228,12 @@ class WallApp(Object, EventTarget, Collection, Application):
 
         self._setup_logger()
 
+        self.logger.info('version #{}'.format(release))
+
         config_paths = [os.path.join(res_path, 'default.cfg')]
         if config_path:
             config_paths.append(config_path)
+            self.logger.info("loading custom configuration from {}".format(config_path))
         try:
             parser = SafeConfigParser()
             parser.read(config_paths)
@@ -342,8 +345,8 @@ class WallApp(Object, EventTarget, Collection, Application):
         except socket.error as e:
             self.logger.error('failed to listen on {}:{}: {}'.format(address, port, str(e)))
             return
-        self.logger.info('server started')
-        baseurl = 'display URL: http://{}:{}'.format(address, port)
+        self.logger.info('webserver started')
+        baseurl = 'http://{}:{}'.format(address, port)
         self.logger.info('display URL: ' + baseurl + '/display')
         self.logger.info('client URL: ' + baseurl)
         IOLoop.instance().start()


### PR DESCRIPTION
Use the logger for all output at startup and fix duplicate prefixes when
printing URLs.
