### PR TITLE
Properly handle keyboard interrupts

### DIFF
--- a/wall.py
+++ b/wall.py
@@ -11,6 +11,10 @@ import wall
 from wall import WallApp
 
 if __name__ == '__main__':
-    # TODO: use option instead
-    config_path = sys.argv[1] if len(sys.argv) >= 2 else None
-    WallApp(config_path=config_path).run()
+    try:
+        # TODO: use option instead
+        config_path = sys.argv[1] if len(sys.argv) >= 2 else None
+        WallApp(config_path=config_path).run()
+    except KeyboardInterrupt:
+        # XXX: could do some cleanup here, if necessary
+        print()


### PR DESCRIPTION
This avoids printing a stack trace on interrupt and adds a place for
cleaning stuff up if necessary at any point in the future.